### PR TITLE
HTTP Signatures -> Signing HTTP Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# W3C HTTP Signatures Working Group Test Suite
+# W3C Signing HTTP Messages Working Group Test Suite
 
 This repository contains the W3C
-[HTTP Signatures](https://tools.ietf.org/html/draft-cavage-http-signatures) test suite.
+[Signing HTTP Messages draft v11](https://tools.ietf.org/html/draft-cavage-http-signatures-11) test suite.
 Any conforming implementation MUST pass all tests in the test suite.
 
 There are multiple test suites, each of which is detailed below.
 
-## HTTP Signatures Tests
+## Signing HTTP Messages Tests
 
-This test suite will check any application that generates [HTTP Signatures](https://tools.ietf.org/html/draft-cavage-http-signatures) Headers to
-ensure conformance with the specification.
+This test suite will check any application that generates headers compliant with
+[Signing HTTP Messages](https://tools.ietf.org/html/draft-cavage-http-signatures)
+to ensure conformance with the specification.
 
 
 ### Creating a Binary

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
   -h, --help                       output usage information
 
 Commands:
-  c14n|canonicalize
+  canonicalize
   sign
   verify
 ```
@@ -41,7 +41,7 @@ All tests will run against the implementation's binary and assume that an exit c
 than 0 represents an error.
 The binary will receive an [HTTP message](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages) via [standard in](https://en.wikipedia.org/wiki/Standard_streams):
 
-Here is an example HTTP message the binary should receive via stdin:
+Here is an example HTTP request the binary should receive via stdin:
 ```
 POST /foo?param=value&pet=dog HTTP/1.1
 Host: example.com
@@ -64,23 +64,25 @@ This is an example local configuration for the test suite. To use:
 
 ### Running the Test Suite
 
-1. npm install
-2. Copy the `config.json.example` file to `config.json` and modify.
-3. All that is needed is a path to the binary that runs the tests
-4. npm test
+1. Install the suite's dependencies and set it up for execution with
+  ``npm install``
+2. Copy the `config.json.example` file to `config.json` and modify with
+  the path of the generator. Note this path must be executable.
+3. ``npm test``
 
 ### Submit an Implementation Report
 
-1. npm install
-2. Copy the `config.json.example` file to `config.json` and modify.
-3. npm run report
-4. Rename implementation/results.json to
-   implementation/YOUR_IMPLEMENTATION-results.json.
-5. git add implementations/YOUR_IMPLEMENTATION-results.json and submit a
-   pull request for the implementation.
+1. Create a fork of the repository <https://github.com/w3c-dvcg/http-signatures-test-suite> on GitHub.
+2. ``npm install``
+3. Copy the `config.json.example` file to `config.json` and modify.
+4. ``npm run report``
+5. Rename ``implementation/results.json`` to
+   ``implementation/YOUR_IMPLEMENTATION-results.json``.
+6. ``git add implementations/YOUR_IMPLEMENTATION-results.json`` and push to your forked repository
+7. Submit a pull request for the results of your implementation to the master repository.
 
 ## Contributing
 
 You may contribute to this test suite by submitting pull requests here:
 
-https://github.com/w3c-dvcg/http-signatures-test-suite
+<https://github.com/w3c-dvcg/http-signatures-test-suite/pulls>

--- a/implementations/generate.js
+++ b/implementations/generate.js
@@ -4,7 +4,7 @@
 'use strict';
 
 /**
- * Generates the HTTP Signatures Implementation Report given
+ * Generates the Signing HTTP Messages Implementation Report given
  * a set of *-report.json files.
  * Expects the report files be the product of your ImplementationReporter.js
  */

--- a/implementations/head.hbs
+++ b/implementations/head.hbs
@@ -1,4 +1,4 @@
-    <title>HTTP Signatures Implementation Report 1.0</title>
+    <title>Signing HTTP Messages draft v11 Implementation Report 1.0</title>
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
     <!--
       === NOTA BENE ===
@@ -15,7 +15,7 @@
         shortName: "http-signatures-implementation-report",
 
         // subtitle for the spec
-        subtitle: "Implementation Report for HTTP Signatures Spec",
+        subtitle: "Implementation Report for Signing HTTP Messages Draft Spec v11",
 
         // if you wish the publication date to be other than today, set this
         //publishDate:  "2017-08-03",

--- a/implementations/implementation.hbs
+++ b/implementations/implementation.hbs
@@ -1,7 +1,7 @@
     <section id='abstract'>
       <p>
 This is the most recent implementation report for the
-<a href="https://tools.ietf.org/html/draft-cavage-http-signatures">HTTP Signatures</a> specification.
+<a href="https://tools.ietf.org/html/draft-cavage-http-signatures">Signing HTTP Messages</a> draft specification v11.
       </p>
     </section>
 
@@ -22,7 +22,7 @@ or send them to
 
       <p>
 The purpose of this document is to demonstrate that there are multiple
-interoperable implementations of HTTP Signatures that are capable of generating
+interoperable implementations of Signing HTTP Messages that are capable of generating
 output that is conformant to the latest version.
       </p>
 
@@ -30,19 +30,19 @@ output that is conformant to the latest version.
         <h2>Testing Methodology</h2>
 
         <p>
-The testing framework for HTTP Signatures executes the
-following process for every conformance statement in the 
+The testing framework for Signing HTTP Messages executes the
+following process for every conformance statement in the
 <a href="https://tools.ietf.org/html/draft-cavage-http-signatures">
-HTTP Signatures specification</a> :
+Signing HTTP Messages specification</a> :
         </p>
 
         <ol class="algorithm">
           <li>
 Take an input HTTP Message that exercises the feature and feed it to a
-developer provided HTTP Signatures binary.
+developer provided Signing HTTP Messages binary.
           </li>
           <li>
-If the input is valid, generate a HTTP Signature that is conformant
+If the input is valid, generate a Signing HTTP Messages header that is conformant
 to options and HTTP message.
           </li>
           <li>

--- a/implementations/index.html
+++ b/implementations/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-        <title>HTTP Signatures Implementation Report 1.0</title>
+        <title>Signing HTTP Messages draft v11 Implementation Report 1.0</title>
         <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
         <!--
           === NOTA BENE ===
@@ -13,33 +13,33 @@
           var respecConfig = {
             // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
             specStatus: "ED",
-    
+
             // the specification's short name, as in http://www.w3.org/TR/short-name/
             shortName: "http-signatures-implementation-report",
-    
+
             // subtitle for the spec
-            subtitle: "Implementation Report for HTTP Signatures Spec",
-    
+            subtitle: "Implementation Report for Signing HTTP Messages Draft Spec v11",
+
             // if you wish the publication date to be other than today, set this
             //publishDate:  "2017-08-03",
-    
+
             // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
             // and its maturity status
             // previousPublishDate:  "1977-03-15",
             // previousMaturity:  "WD",
-    
+
             // extend the bibliography entries
             doJsonLd: true,
-    
+
             github: "https://github.com/w3c-dvcg/http-signatures-test-suite",
             includePermalinks: false,
-    
+
             // if there a publicly available Editor's Draft, this is the link
             edDraftURI: "https://tools.ietf.org/html/draft-cavage-http-signatures",
-    
+
             // if this is a LCWD, uncomment and set the end of its review period
             // lcEnd: "2009-08-05",
-    
+
             // editors, add as many as you like
             // only "name" is required
             editors:  [
@@ -58,13 +58,13 @@
             ],
             // name of the WG
             wg:           "W3C Digital Verification Community Group",
-    
+
             // URI of the public WG page
             wgURI:        "https://w3c-dvcg.github.io/",
-    
+
             // name (with the @w3c.org) of the public mailing to which comments are due
             wgPublicList: "public-credentials",
-    
+
             // URI of the patent status for this WG, for Rec-track documents
             // !!!! IMPORTANT !!!!
             // This is important for Rec-track documents, do not copy a patent URI from a random
@@ -98,10 +98,10 @@
         <section id='abstract'>
           <p>
     This is the most recent implementation report for the
-    <a href="https://tools.ietf.org/html/draft-cavage-http-signatures">HTTP Signatures</a> specification.
+    <a href="https://tools.ietf.org/html/draft-cavage-http-signatures">Signing HTTP Messages</a> draft specification v11.
           </p>
         </section>
-    
+
         <section id='sotd'>
           <p>
     Comments regarding this document are welcome. Please file issues
@@ -111,35 +111,35 @@
     (<a href="mailto:public-credentials@w3.org?subject=subscribe">subscribe</a>,
     <a href="https://lists.w3.org/Archives/Public/public-credentials/">archives</a>).
           </p>
-    
+
         </section>
-    
+
         <section class="informative">
           <h1>Introduction</h1>
-    
+
           <p>
     The purpose of this document is to demonstrate that there are multiple
-    interoperable implementations of HTTP Signatures that are capable of generating
+    interoperable implementations of Signing HTTP Messages that are capable of generating
     output that is conformant to the latest version.
           </p>
-    
+
           <section class="informative">
             <h2>Testing Methodology</h2>
-    
+
             <p>
-    The testing framework for HTTP Signatures executes the
-    following process for every conformance statement in the 
+    The testing framework for Signing HTTP Messages executes the
+    following process for every conformance statement in the
     <a href="https://tools.ietf.org/html/draft-cavage-http-signatures">
-    HTTP Signatures specification</a> :
+    Signing HTTP Messages draft specification v11</a> :
             </p>
-    
+
             <ol class="algorithm">
               <li>
     Take an input HTTP Message that exercises the feature and feed it to a
-    developer provided HTTP Signatures binary.
+    developer provided Signing HTTP Messages binary.
               </li>
               <li>
-    If the input is valid, generate a HTTP Signature that is conformant
+    If the input is valid, generate a Signing HTTP Messages header that is conformant
     to options and HTTP message.
               </li>
               <li>
@@ -147,9 +147,9 @@
     conformant to the feature being tested.
               </li>
             </ol>
-    
+
           </section>
-    
+
         </section>
     <section class="informative">
       <h1>Conformance Testing Results</h1>


### PR DESCRIPTION
USe the proper name of this specification in documentation. Also make clear this evaluates v11 - entirely compliant v10 implementations are now broken, even though the version is marked experimental.

Does this really matter? This has caused endless confusion in at least my own discussions. It has a name, we should use that name, and be consistent in how we use that name.